### PR TITLE
chore(coverage): Get proper coverage on all files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
+sudo: false
 language: node_js
 node_js:
-  - "node"
-after_success: npm run coverage
+  - "stable"
+
+after_success: "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "commit": "git cz",
     "repl": "node repl",
     "test": "cross-env NODE_ENV=test nyc ava",
-    "coverage": "nyc report --reporter=text-lcov | coveralls",
     "test:watch": "ava -w"
   },
   "repository": {
@@ -28,11 +27,13 @@
     "Interpreter"
   ],
   "ava": {
+    "babel": "inherit",
     "require": [
       "babel-register"
     ]
   },
   "nyc": {
+    "all": true,
     "lines": 90,
     "statements": 90,
     "functions": 90,
@@ -46,10 +47,6 @@
     "check-coverage": true,
     "include": [
       "src/**/*.js"
-    ],
-    "exclude": [
-      "lib/**/*.js",
-      "**/*.test.js"
     ]
   },
   "bugs": {
@@ -57,7 +54,7 @@
   },
   "homepage": "https://github.com/rsnara/glisp#readme",
   "devDependencies": {
-    "ava": "^0.15.2",
+    "ava": "^0.16.0",
     "babel-plugin-istanbul": "^1.0.3",
     "babel-preset-es2015-rollup": "^1.1.1",
     "babel-preset-stage-0": "^6.5.0",


### PR DESCRIPTION
Also move coveralls script to travis config, since it's only for the CI server [and not developers]
to run. Use stable node on Travis (which uses `nvm install stable`).

Update ava version.

@rsnara you'll notice the build fails because the _true_ coverage doesn't actually match the thresholds. I could just bump them down in a separate commit [that'll get squashed anyway I guess]... but you'll probably need to re-`rm -rf node_modules && npm cache clear && npm install` - I was seeing some strange babel issues with `all` enabled and that fixed it.
