### PR TITLE
feat(*): Implement strings and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ GLISP uses [Immutable.js](https://facebook.github.io/immutable-js/) to power its
 ```
 
 ## Numbers
-For the time being all numbers are instances of [BigNumber](https://github.com/MikeMcl/bignumber.js/). There is support for fractional numbers. Support for floating point numbers will be added later on.
+For the time being all numbers are either instances of [BigNumber](https://github.com/MikeMcl/bignumber.js/), or [Fraction](https://github.com/infusion/Fraction.js/). Support for floating point numbers will be added later on.
 
 ```LISP
 ;; BigNumbers!
@@ -74,6 +74,16 @@ For the time being all numbers are instances of [BigNumber](https://github.com/M
 
 ;; Fractions
 (+ 1/3 2/3) ;; 1
+```
+
+## Strings
+Strings also implemented and can be created using double quotes.
+
+```LISP
+"Produce side effects!"
+"This is a multiline string!
+  Yay!"
+"You can also \"quote\" within strings!")
 ```
 
 ## Development

--- a/src/create-ast.js
+++ b/src/create-ast.js
@@ -3,9 +3,6 @@ import createParenMap from './create-paren-map';
 import createAtom from './create-atom';
 import * as Util from './util/index';
 
-// Have () parse to a Stack
-// Have [] parse to a list
-
 export default function createAst(tokens) {
   const endingParen = createParenMap(tokens);
 

--- a/src/create-atom.js
+++ b/src/create-atom.js
@@ -18,5 +18,13 @@ export default function createAtom(x) {
     return M.bignumber(x);
   }
 
+  if (isString(x)) {
+    return x.substring(1, x.length - 1);
+  }
+
   return Symbol.for(x);
+}
+
+function isString(string) {
+  return string.startsWith('"') && string.endsWith('"');
 }

--- a/src/evaluate/special-forms/do.test.js
+++ b/src/evaluate/special-forms/do.test.js
@@ -1,3 +1,4 @@
+import * as M from 'mathjs';
 import test from 'ava';
 import { parse, evaluate } from '../../index';
 
@@ -44,4 +45,14 @@ test('should return undefined when called with an empty body', (assert) => {
   `));
 
   assert.is(result, undefined);
+});
+
+test('should allow user to specify intent via a string', (assert) => {
+  const result = evaluate({}, parse(`
+    (do
+      "This is for not performing side effects!"
+      3)
+  `));
+
+  assert.truthy(M.equal(result, 3));
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import run from './run';
 import RootEnv from './root-env';
 import evaluate from './evaluate/index';
+import tokenize from './tokenize';
 import parse from './parse';
 
-export { run, RootEnv, evaluate, parse };
+export { run, RootEnv, evaluate, parse, tokenize };

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -1,14 +1,59 @@
-import * as Util from './util/index';
+import * as I from 'immutable';
+import * as R from 'ramda';
 
 export default function tokenize(program) {
-  return Util.stripComments(program)
-    .replace(/\[/g, ' [ ')
-    .replace(/\]/g, ' ] ')
-    .replace(/\(/g, ' ( ')
-    .replace(/\)/g, ' ) ')
-    .replace(/#{/g, ' #{ ')
-    .replace(/([^#]|^){/g, '$1 { ')
-    .replace(/}/g, ' } ')
-    .split(/[,\s]/)
-    .filter(Boolean);
+  const [tokens, buffer] = R.reduce(buildTokens, [I.List(), ''], program);
+  return tokens.push(buffer).filter(R.complement(isComment)).filter(Boolean).toJS();
+}
+
+function buildTokens([tokens, buffer], token) {
+  if (isString(buffer)) {
+    if (token === '"' && R.last(buffer) !== '\\') {
+      return [ tokens.push(buffer + token), '' ];
+    }
+
+    if (token === '"' && R.last(buffer) === '\\') {
+      return [ tokens, buffer.substring(0, buffer.length - 1) + token];
+    }
+
+    return [ tokens, buffer + token ];
+  }
+
+  if (isComment(buffer)) {
+    if (token === '\n') {
+      return [ tokens.push(buffer), '' ];
+    }
+
+    return [ tokens, buffer + token ];
+  }
+
+  if (token === '#') {
+    return [ tokens.push(buffer), token ];
+  }
+
+  if (buffer === '#' && token === '{') {
+    return [ tokens.push('#{'), '' ];
+  }
+
+  if (['{', '}', '[', ']', '(', ')'].includes(token)) {
+    return [ tokens.push(buffer, token), '' ];
+  }
+
+  if (isWhitespace(token)) {
+    return [ tokens.push(buffer), '' ];
+  }
+
+  return [ tokens, buffer + token ];
+}
+
+function isWhitespace(string) {
+  return /(\s|,)+/.test(string);
+}
+
+function isComment(string) {
+  return string.startsWith(';');
+}
+
+function isString(string) {
+  return string.startsWith('"');
 }

--- a/src/tokenize.test.js
+++ b/src/tokenize.test.js
@@ -103,3 +103,117 @@ test('should strip comments in multiple lines', (assert) => {
 
   assert.deepEqual(tokens, ['+']);
 });
+
+test('should not tokenize strings within comments', (assert) => {
+  const tokens = tokenize(`
+    ; "I'm a string!"
+  `);
+
+  assert.deepEqual(tokens, []);
+});
+
+test('should not tokenize Set literals within comments', (assert) => {
+  const tokens = tokenize(`
+    ; #{1 2}
+    ;; This is another comment!
+    ; #{1} #{2}
+    #{}
+  `);
+
+  assert.deepEqual(tokens, ['#{', '}']);
+});
+
+test('should not tokenize Map literals within comments', (assert) => {
+  const tokens = tokenize(`
+    ; {1 2 3 4 5 6}
+    ;; This is another comment!
+    ; {1} {2}
+    {}
+  `);
+
+  assert.deepEqual(tokens, ['{', '}']);
+});
+
+test('should not tokenize List literals within comments', (assert) => {
+  const tokens = tokenize(`
+    ; [1 2 3 4 5 6]
+    ;; This is another comment!
+    ; [1] [2]
+    [1 23 4]
+  `);
+
+  assert.deepEqual(tokens, ['[', '1', '23', '4', ']']);
+});
+
+test('should not tokenize Stack literals within comments', (assert) => {
+  const tokens = tokenize(`
+    ;; This is my super special comment
+    (One two three)  ;; This is another super special comment!
+    ;; (one two three four five six seven)
+  `);
+
+  assert.deepEqual(tokens, ['(', 'One', 'two', 'three', ')']);
+});
+
+test('should not tokenize comments within comments', (assert) => {
+  const tokens = tokenize(`
+    1 ;; 2 ;; 3 ;; 4
+  `);
+
+  assert.deepEqual(tokens, ['1']);
+});
+
+test('should tokenize single line strings', (assert) => {
+  const tokens = tokenize('"This is a string!"');
+  assert.deepEqual(tokens, ['"This is a string!"']);
+});
+
+test('should tokenize multiline strings correctly', (assert) => {
+  const tokens = tokenize(`
+    1 2
+    "Super special awesome
+    Multiline String" ;; 4 spaces
+  `);
+  assert.deepEqual(tokens, ['1', '2', '"Super special awesome\n    Multiline String"']);
+});
+
+test('should tokenize strings with escaped instances of "', (assert) => {
+  const tokens = tokenize('"I am a \\"frog\\", you fish."');
+  assert.deepEqual(tokens, ['"I am a "frog", you fish."']);
+});
+
+
+test('should not tokenize Map literals within strings', (assert) => {
+  const tokens = tokenize(`
+    "This is a map: {1 2}"
+  `);
+  assert.deepEqual(tokens, ['"This is a map: {1 2}"']);
+});
+
+test('should not tokenize Set literals within strings', (assert) => {
+  const tokens = tokenize(`
+    "This is a set: #{1 2}"
+  `);
+  assert.deepEqual(tokens, ['"This is a set: #{1 2}"']);
+});
+
+test('should not tokenize List literals within strings', (assert) => {
+  const tokens = tokenize(`
+    "This is a List: [[1 2] [2]]"
+  `);
+  assert.deepEqual(tokens, ['"This is a List: [[1 2] [2]]"']);
+});
+
+test('should not tokenize Stack literals within strings', (assert) => {
+  const tokens = tokenize(`
+    "This is an executable form: (+ 1 2 3)"
+  `);
+  assert.deepEqual(tokens, ['"This is an executable form: (+ 1 2 3)"']);
+});
+
+test('should not tokenize comments within strings', (assert) => {
+  const tokens = tokenize(`
+    "This is a comment within a string: ;; I'm a comment!"
+  `);
+  assert.deepEqual(tokens, ['"This is a comment within a string: ;; I\'m a comment!"']);
+});


### PR DESCRIPTION
### Changes
- Re-implemented the tokenizer to incorporate string and comment syntax

Hmm... I thought there was more to this PR, but I guess not. Anyways, the tokenizer is the only real change.
#### Tangential comment

I need to find a good place to put a bunch of e2e tests to make sure important language features just work. Right now, the best place where such tests lie are under `/src/evaluate/special-forms`. 
