### PR TITLE
chore(release): Add release script with standard-version and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+<a name="0.2.1"></a>
+## 0.2.1 (2016-08-17)
+
+
+### Bug Fixes
+
+* **root-env:** Fix '=' function ([c087993](https://github.com/rsnara/glisp/commit/c087993))
+
+
+### Features
+
+* Add a repl ([cb19789](https://github.com/rsnara/glisp/commit/cb19789))
+* Implement strings and comments ([c71ec53](https://github.com/rsnara/glisp/commit/c71ec53))
+* Initial commit. ([cd3a98f](https://github.com/rsnara/glisp/commit/cd3a98f))
+* Partially implement JS Interop ([4819a72](https://github.com/rsnara/glisp/commit/4819a72))
+* **evaluate:** Throw an error if trying to deref a symbol that has no definition attached ([c257c34](https://github.com/rsnara/glisp/commit/c257c34))
+* **root-env:** Implement 'aset' and 'aget' ([8811b49](https://github.com/rsnara/glisp/commit/8811b49))
+* **tokenize:** Strip comments before tokenizing ([95fe25c](https://github.com/rsnara/glisp/commit/95fe25c))

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "prepublish": "npm run build",
     "commit": "git cz",
     "repl": "node repl",
+    "prerelease": "npm test",
+    "release": "standard-version",
+    "postrelease": "git push --follow-tags && npm publish",
     "test": "cross-env NODE_ENV=test nyc ava",
     "test:watch": "ava -w"
   },
@@ -71,6 +74,7 @@
     "rollup": "^0.34.3",
     "rollup-plugin-babel": "^2.6.1",
     "rollup-watch": "^2.5.0",
+    "standard-version": "^2.4.0",
     "testdouble": "^1.6.0"
   },
   "dependencies": {


### PR DESCRIPTION
Now every time you want to publish a new version to npm, just use `npm run release` and it will figure out the versioning and changelog stuff for you :)
