### PR TITLE
feat(*): Implement reader macros for quote and unquote

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ run('(+ 1 2)') // 3
 
 ;; macros
 (def defn (macro [name args body]
-            (quote
-              (def (unquote name) (fn (unquote args) (unquote body))))))
+            `(def ~name (fn ~args ~body)))))
 
 (defn double [x] (* x 2))
 (double 2)  ;; 4

--- a/src/create-ast.js
+++ b/src/create-ast.js
@@ -29,6 +29,23 @@ export default function createAst(tokens) {
       return [ buildMap(I.Map(), i, end, i + 1), end + 1 ];
     }
 
+    // TODO: Re-implement so reader macros aren't inlined
+    if (['\'', '`', '~'].includes(token)) {
+      if (i + 1 === tokens.length) {
+        throw new Error(`${token} must be followed by a form, found none.`);
+      }
+    }
+
+    if (token === '\'' || token === '`') {
+      const [ form, next ] = build(i + 1);
+      return [ I.Stack.of( createAtom('quote'), form ), next ];
+    }
+
+    if (token === '~') {
+      const [ form, next ] = build(i + 1);
+      return [ I.Stack.of( createAtom('unquote'), form ), next ];
+    }
+
     return [ createAtom(token), i + 1 ];
   }
 

--- a/src/create-ast.test.js
+++ b/src/create-ast.test.js
@@ -162,3 +162,114 @@ test('should throw if a map literal has an odd number of args', (assert) => {
   const tokens = ['{', ...elements, '}'];
   assert.throws(() => createAst(tokens));
 });
+
+['\'', '`'].forEach((token) => {
+  test(`should quote Stacks prefixed with ${token}`, (assert) => {
+    const elements = [token, '(', '1', '2', '3', ')'];
+    const ast = createAst(elements);
+    assert.true(I.is(
+      ast,
+      I.Stack.of('quote', I.Stack.of('1', '2', '3' )),
+    ));
+  });
+
+  test(`should quote Lists prefixed with ${token}`, (assert) => {
+    const elements = [token, '[', '(', '2', ')', '3', ']'];
+    const ast = createAst(elements);
+    assert.true(I.is(
+      ast,
+      I.Stack.of('quote', I.List.of(I.Stack.of('2'), '3')),
+    ));
+  });
+
+  test(`should quote Sets prefixed with ${token}`, (assert) => {
+    const elements = [token, '#{', '[', '2', ']', '3', '}'];
+    const ast = createAst(elements);
+    assert.true(I.is(
+      ast,
+      I.Stack.of('quote', I.Set.of(I.List.of('2'), '3')),
+    ));
+  });
+
+  test(`should quote Maps prefixed with ${token}`, (assert) => {
+    const elements = [token, '{', '[', '2', ']', '3', '}'];
+    const ast = createAst(elements);
+    assert.true(I.is(
+      ast,
+      I.Stack.of('quote', I.Map.of(I.List.of('2'), '3')),
+    ));
+  });
+
+  test(`should quote symbols prefixed with ${token}`, (assert) => {
+    const elements = [token, '#{', '[', '\'', 'horse', ']', '3', '}'];
+    const ast = createAst(elements);
+    assert.true(I.is(
+      ast,
+      I.Stack.of('quote', I.Set.of(I.List.of(I.Stack.of('quote', 'horse')), '3')),
+    ));
+  });
+
+  test(`should quote numbers prefixed with ${token}`, (assert) => {
+    const elements = [token, '#{', '[', '\'', '1', ']', '3', '}'];
+    const ast = createAst(elements);
+    assert.true(I.is(
+      ast,
+      I.Stack.of('quote', I.Set.of(I.List.of(I.Stack.of('quote', '1')), '3')),
+    ));
+  });
+
+  test(`should quote Stacks prefixed with ${token}`, (assert) => {
+    const elements = [token, '(', '1', '2', '3', ')'];
+    const ast = createAst(elements);
+    assert.true(I.is(
+      ast,
+      I.Stack.of('quote', I.Stack.of('1', '2', '3' )),
+    ));
+  });
+
+  test(`should throw an error when no forms follow ${token}`, (assert) => {
+    const elements = [token];
+    assert.throws(() => createAst(elements));
+  });
+});
+
+test('should unquote numbers prefixed with ~', (assert) => {
+  const elements = ['~', '1'];
+  const ast = createAst(elements);
+  assert.true(I.is(ast, I.Stack.of('unquote', '1')));
+});
+
+test('should unquote Sets prefixed with ~', (assert) => {
+  const elements = ['~', '#{', '1', '}'];
+  const ast = createAst(elements);
+  assert.true(I.is(ast, I.Stack.of('unquote', I.Set.of('1'))));
+});
+
+test('should unquote Lists prefixed with ~', (assert) => {
+  const elements = ['~', '[', '1', ']'];
+  const ast = createAst(elements);
+  assert.true(I.is(ast, I.Stack.of('unquote', I.List.of('1'))));
+});
+
+test('should unquote Stacks prefixed with ~', (assert) => {
+  const elements = ['~', '(', '1', ')'];
+  const ast = createAst(elements);
+  assert.true(I.is(ast, I.Stack.of('unquote', I.Stack.of('1'))));
+});
+
+test('should unquote Maps prefixed with ~', (assert) => {
+  const elements = ['~', '{', '1', '[', ']', '}'];
+  const ast = createAst(elements);
+  assert.true(I.is(ast, I.Stack.of('unquote', I.Map.of('1', I.List()))));
+});
+
+test('should throw an error when no forms follow ~', (assert) => {
+  const elements = ['~'];
+  assert.throws(() => createAst(elements));
+});
+
+test('should parse quote within unquote within a quote', (assert) => {
+  const elements = ['`', '~', '\'', '1'];
+  const ast = createAst(elements);
+  assert.true(I.is(ast, I.Stack.of('quote', I.Stack.of('unquote', I.Stack.of('quote', '1')))));
+});

--- a/src/evaluate/special-forms/macro.test.js
+++ b/src/evaluate/special-forms/macro.test.js
@@ -13,7 +13,7 @@ test('should enable the implementation of defn', (assert) => {
     (do
       (def defn
         (macro [name arg-names & body]
-          (Stack (quote def) name (concat (Stack (quote fn) arg-names) body))))
+          (Stack 'def name (concat (Stack 'fn arg-names) body))))
       (defn add [x y] 1 (+ x y))
       (defn identity [x] x))
   `);

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -27,6 +27,18 @@ function buildTokens([tokens, buffer], token) {
     return [ tokens, buffer + token ];
   }
 
+  if (token === '~') {
+    return [ tokens.push(buffer), token ];
+  }
+
+  if (buffer === '~') {
+    if (token === '@') {
+      return [ tokens.push('~@'), '' ];
+    }
+
+    return [ tokens.push('~'), token ];
+  }
+
   if (token === '#') {
     return [ tokens.push(buffer), token ];
   }
@@ -35,7 +47,7 @@ function buildTokens([tokens, buffer], token) {
     return [ tokens.push('#{'), '' ];
   }
 
-  if (['{', '}', '[', ']', '(', ')'].includes(token)) {
+  if (['{', '}', '[', ']', '(', ')', '\'', '`'].includes(token)) {
     return [ tokens.push(buffer, token), '' ];
   }
 

--- a/src/tokenize.test.js
+++ b/src/tokenize.test.js
@@ -224,3 +224,19 @@ test('should tokenize List literals beside regular symbols', (assert) => {
   `);
   assert.deepEqual(tokens, ['(', 'defn', 'id', '[', 'x', ']', 'x', ')']);
 });
+
+['#{', '{', '}', '[', ']', '(', ')', '\'', '`', '~', '~@'].forEach((token) => {
+  test(`should tokenize ${token} beside forms`, (assert) => {
+    const tokens = tokenize(`
+      ${token}horse
+    `);
+    assert.deepEqual(tokens, [token, 'horse']);
+  });
+
+  test('should tokenize ${token} between forms', (assert) => {
+    const tokens = tokenize(`
+      cow${token}horse
+    `);
+    assert.deepEqual(tokens, ['cow', token, 'horse']);
+  });
+});


### PR DESCRIPTION
This PR implements reader macros for quote and unquote. 

```Clojure
;; Before
(def defn (macro [name args body]
                  (Stack (quote def) name (Stack (quote fn) args body))))

;; After
(def defn (macro [name args body] 
                  `(def ~name (fn ~args ~body))))
```

Although it may look like it, we don't really have the syntax quote. It'll have to be implemented correctly once namespaces exist.

Edit. The tokenizer will also recognize `~@` as a token, but that doesn't really have an effect on the AST as of yet.